### PR TITLE
Support per-buffer enable/disable settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,14 @@ behavior with the following line:
 
     let g:terminal_images_auto = 0
 
-Or use `:TerminalImagesToggle` to toggle this behavior. When automatic preview
-is disabled you can trigger it manually with `:TerminalImagesShowAll`.
+Or use `:TerminalImagesEnable`, `:TerminalImagesDisable` or
+`:TerminalImagesToggle` to toggle this behavior. When automatic preview is
+disabled you can trigger it manually with `:TerminalImagesShowAll`.
+
+To enable or disable the plugin for the current buffer only, use
+`:TerminalImagesEnableBuffer`, `:TerminalImagesDisableBuffer`. Note that buffer
+settings has a precedence over the gloabl one. To clear the buffer
+setting in favor of the global one, use `:TerminalImagesUnletBuffer`.
 
 To hide images in the current buffer use `:TerminalImagesClear`. If you think
 some of the images failed to upload correctly, use

--- a/autoload/terminal_images.vim
+++ b/autoload/terminal_images.vim
@@ -616,21 +616,21 @@ function! terminal_images#CloseObscuringImages() abort
 endfun
 
 function! terminal_images#ShowAllMaybe() abort
-    if g:terminal_images_auto
+    if s:Get('terminal_images_auto')
         call terminal_images#ShowAllImages({})
-    elseif g:terminal_images_auto_show_current
+    elseif s:Get('terminal_images_auto_show_current')
         call terminal_images#ShowCurrentFile({})
     endif
 endfun
 
 function! terminal_images#ShowCurrentMaybe() abort
-    if g:terminal_images_auto_show_current
+    if s:Get('terminal_images_auto_show_current')
         call terminal_images#ShowCurrentFile({})
     endif
 endfun
 
 function! terminal_images#CloseObscuringMaybe() abort
-    if g:terminal_images_auto
+    if s:Get('terminal_images_auto')
         call terminal_images#CloseObscuringImages()
     endif
 endfun
@@ -654,3 +654,26 @@ function! terminal_images#ToggleGlobal() abort
         call terminal_images#EnableGlobal()
     endif
 endfun
+
+function! terminal_images#EnableBuffer() abort
+    let b:terminal_images_auto = 1
+    call terminal_images#ShowAllImages({})
+    echom "Automatic image display is on for this buffer"
+endfun
+
+function! terminal_images#DisableBuffer() abort
+    let b:terminal_images_auto = 0
+    call terminal_images#ClearVisibleImages()
+    echom "Automatic image display is off for this buffer"
+endfun
+
+function! terminal_images#ClearBufferEnableSettings() abort
+    unlet b:terminal_images_auto
+    if s:Get('terminal_images_auto')
+      call terminal_images#ShowAllImages({})
+    else
+      call terminal_images#ClearVisibleImages()
+    endif
+    echom "Automatic image display uses global settings"
+endfun
+

--- a/autoload/terminal_images.vim
+++ b/autoload/terminal_images.vim
@@ -7,7 +7,8 @@ function! s:GetWindowWidth() abort
 endfun
 
 " Get the value of a buffer variable, or a global variable if the buffer
-" variable is missing.
+" variable is missing. So, buffer settings have precedence over the global
+" ones.
 function! s:Get(name) abort
     return get(b:, a:name, get(g:, a:name))
 endfun
@@ -473,7 +474,7 @@ function! terminal_images#ShowAllImages(params) abort
     " If there is nothing to show, try to show the current file.
     if empty(file_list)
         let w:terminal_images_prev_finished = 1
-        if g:terminal_images_auto_show_current
+        if s:Get('terminal_images_auto_show_current')
             call terminal_images#ShowCurrentFile(a:params)
         endif
         return
@@ -620,6 +621,8 @@ function! terminal_images#ShowAllMaybe() abort
         call terminal_images#ShowAllImages({})
     elseif s:Get('terminal_images_auto_show_current')
         call terminal_images#ShowCurrentFile({})
+    else
+        echom "Terminal images is disabled or has nothing to show"
     endif
 endfun
 
@@ -637,13 +640,17 @@ endfun
 
 function! terminal_images#EnableGlobal() abort
     let g:terminal_images_auto = 1
-    call terminal_images#ShowAllImages({})
+    if s:Get('terminal_images_auto')
+       call terminal_images#ShowAll({})
+    endif
     echom "Automatic image display is on"
 endfun
 
 function! terminal_images#DisableGlobal() abort
     let g:terminal_images_auto = 0
-    call terminal_images#ClearVisibleImages()
+    if ! s:Get('terminal_images_auto')
+        call terminal_images#ClearVisibleImages()
+    endif
     echom "Automatic image display is off"
 endfun
 
@@ -655,12 +662,16 @@ function! terminal_images#ToggleGlobal() abort
     endif
 endfun
 
+" Enable images for this buffer. Buffer settings have precedence over the
+" global ones.
 function! terminal_images#EnableBuffer() abort
     let b:terminal_images_auto = 1
-    call terminal_images#ShowAllImages({})
+    call terminal_images#ShowAll({})
     echom "Automatic image display is on for this buffer"
 endfun
 
+" Disable images for this buffer only. Buffer settings have precedence over
+" the global ones.
 function! terminal_images#DisableBuffer() abort
     let b:terminal_images_auto = 0
     call terminal_images#ClearVisibleImages()

--- a/plugin/terminal-images.vim
+++ b/plugin/terminal-images.vim
@@ -79,6 +79,9 @@ command TerminalImagesShowUnderCursorIfReadable :call terminal_images#ShowImageU
 command TerminalImagesToggle :call terminal_images#ToggleGlobal()
 command TerminalImagesEnable :call terminal_images#EnableGlobal()
 command TerminalImagesDisable :call terminal_images#DisableGlobal()
+command TerminalImagesEnableBuffer :call terminal_images#EnableBuffer()
+command TerminalImagesDisableBuffer :call terminal_images#DisableBuffer()
+command TerminalImagesUnletBuffer :call terminal_images#ClearBufferEnableSettings()
 " Show the current buffer if it's an image.
 command TerminalImagesShowCurrent :call terminal_images#ShowCurrentFile({})
 " Show all images found in the current window.


### PR DESCRIPTION
The main use-case for this is currently to disable images in auxiliary buffers like the NERDTree ones.

``` vim
autocmd FileType nerdtree call terminal_images#DisableBuffer()
```

This seems to work fine, although the hooking the FileType event might be not a perfect choice for filtering specific buffers.